### PR TITLE
Fix Rails 6.1 compatibility with concurrent-ruby 1.3.5+

### DIFF
--- a/lib/simple_mysql_partitioning.rb
+++ b/lib/simple_mysql_partitioning.rb
@@ -1,4 +1,7 @@
 require 'simple_mysql_partitioning/version'
+# Explicitly require logger for concurrent-ruby 1.3.5+ compatibility with Rails 6.1/7.0
+# concurrent-ruby 1.3.5+ removed its logger dependency, which ActiveSupport assumes is loaded
+require 'logger'
 require 'active_record'
 require 'mysql2'
 require 'simple_mysql_partitioning/adapter'

--- a/simple_mysql_partitioning.gemspec
+++ b/simple_mysql_partitioning.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord', '>= 6.1.0', '< 8.0'
   spec.add_dependency 'activesupport', '>= 6.1.0', '< 8.0'
-  # Pin concurrent-ruby to < 1.3.5 for Rails 6.1 compatibility
-  # concurrent-ruby 1.3.5+ removed logger dependency causing NameError with Rails 6.1
-  spec.add_dependency 'concurrent-ruby', '~> 1.3.0', '< 1.3.5'
+  # concurrent-ruby 1.3.5+ removed logger dependency
+  # We explicitly require logger in lib/simple_mysql_partitioning.rb for Rails 6.1/7.0 compatibility
+  spec.add_dependency 'concurrent-ruby', '~> 1.3.0', '< 1.3.7'
   spec.add_development_dependency 'mysql2', '~> 0.5.6'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.13'


### PR DESCRIPTION
This commit addresses the CI failure in PR #21 by explicitly requiring the logger library before loading ActiveRecord.

Background:
- concurrent-ruby 1.3.5+ removed its logger dependency to fix Ruby 3.3.5 warnings about logger being removed from default gems in Ruby 3.5
- This change exposed that ActiveSupport assumes Logger is already loaded, causing "uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger" errors in Rails 6.1 and 7.0

Solution:
- Explicitly require 'logger' in lib/simple_mysql_partitioning.rb before requiring ActiveRecord
- Update concurrent-ruby constraint to allow versions up to 1.3.7
- Update comments to document the workaround

This allows the gem to use newer concurrent-ruby versions (1.3.5+) while maintaining compatibility with Rails 6.1 and 7.0.

References:
- https://github.com/rails/rails/issues/54272
- https://github.com/ruby-concurrency/concurrent-ruby/issues/1077